### PR TITLE
fix: infinitely fetching meetups

### DIFF
--- a/client/src/components/footer.tsx
+++ b/client/src/components/footer.tsx
@@ -41,7 +41,7 @@ export function Footer() {
         console.error(error);
       }
     })();
-  });
+  }, []);
 
   const unsetContinents = meetups.map((meetup) => meetup.continent);
   const continents = [...new Set(unsetContinents)];

--- a/package.json
+++ b/package.json
@@ -25,7 +25,8 @@
     "prettier": "3.0.3",
     "ts-node": "10.9.1",
     "turbo": "1.10.16",
-    "typescript": "5.2.2"
+    "typescript": "5.2.2",
+    "cross-env": "7.0.3"
   },
   "pnpm": {
     "peerDependencyRules": {
@@ -45,8 +46,5 @@
   "engines": {
     "node": ">=18",
     "pnpm": ">=8"
-  },
-  "dependencies": {
-    "cross-env": "^7.0.3"
   }
 }

--- a/package.json
+++ b/package.json
@@ -45,5 +45,8 @@
   "engines": {
     "node": ">=18",
     "pnpm": ">=8"
+  },
+  "dependencies": {
+    "cross-env": "^7.0.3"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,6 +7,10 @@ settings:
 importers:
 
   .:
+    dependencies:
+      cross-env:
+        specifier: ^7.0.3
+        version: 7.0.3
     devDependencies:
       '@trivago/prettier-plugin-sort-imports':
         specifier: 4.2.1
@@ -1660,6 +1664,14 @@ packages:
 
   /create-require@1.1.1:
     resolution: {integrity: sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==}
+
+  /cross-env@7.0.3:
+    resolution: {integrity: sha512-+/HKd6EgcQCJGh2PSjZuUitQBQynKor4wrFbRg4DtAgS1aWO+gU52xpH7M9ScGgXSYmAVS9bIJ8EzuaGw0oNAw==}
+    engines: {node: '>=10.14', npm: '>=6', yarn: '>=1'}
+    hasBin: true
+    dependencies:
+      cross-spawn: 7.0.3
+    dev: false
 
   /cross-spawn@7.0.3:
     resolution: {integrity: sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,10 +7,6 @@ settings:
 importers:
 
   .:
-    dependencies:
-      cross-env:
-        specifier: ^7.0.3
-        version: 7.0.3
     devDependencies:
       '@trivago/prettier-plugin-sort-imports':
         specifier: 4.2.1
@@ -27,6 +23,9 @@ importers:
       '@typescript-eslint/eslint-plugin':
         specifier: 6.10.0
         version: 6.10.0(@typescript-eslint/parser@6.10.0)(eslint@8.53.0)(typescript@5.2.2)
+      cross-env:
+        specifier: 7.0.3
+        version: 7.0.3
       eslint:
         specifier: 8.53.0
         version: 8.53.0
@@ -1671,7 +1670,7 @@ packages:
     hasBin: true
     dependencies:
       cross-spawn: 7.0.3
-    dev: false
+    dev: true
 
   /cross-spawn@7.0.3:
     resolution: {integrity: sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==}


### PR DESCRIPTION
just adds the missing `useEffect` dependency, and the defines the `cross-env` in the root `package.json` instead of assuming it's globally available.